### PR TITLE
Add support to execute custom testng.xml file

### DIFF
--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -26,6 +26,8 @@ FILE5=const.py
 FILE6=requirements.txt
 FILE7=intg-test-runner.sh
 FILE8=intg-test-runner.bat
+FILE9=testng.xml
+FILE10=testng-server-mgt.xml
 
 PROP_KEY=sshKeyFileLocation      #pem file
 PROP_OS=OS                       #OS name e.g. centos
@@ -144,6 +146,8 @@ if [ "${os}" = "Windows" ]; then
   echo $(sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE5} ${user}@${host}:${REM_DIR})
   echo $(sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE6} ${user}@${host}:${REM_DIR})
   echo $(sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE8} ${user}@${host}:${REM_DIR})
+  echo $(sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE9} ${user}@${host}:${REM_DIR})
+  echo $(sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE10} ${user}@${host}:${REM_DIR})
 
   echo "=== Files copying finished ==="
   echo "Execution begins.. "
@@ -166,6 +170,9 @@ else
   scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE5} ${user}@${host}:${REM_DIR}
   scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE6} ${user}@${host}:${REM_DIR}
   scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE7} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE9} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE10} ${user}@${host}:${REM_DIR}
+
   echo "=== Files copied successfully ==="
 
   ssh -o StrictHostKeyChecking=no -i ${key_pem} ${user}@${host} bash ${REM_DIR}/intg-test-runner.sh --wd ${REM_DIR}

--- a/integration-tests/testng-escaping Windows hang testcases.xml
+++ b/integration-tests/testng-escaping Windows hang testcases.xml
@@ -1,0 +1,236 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Identity-suite-initializer">
+    <parameter name="useDefaultListeners" value="false"/>
+    <listeners>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestExecutionListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestManagerListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestReportListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestSuiteListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestTransformerListener"/>
+        <listener class-name="org.wso2.identity.integration.test.listeners.IdentityTestListener"/>
+    </listeners>
+
+    <test name="is-tests-initialize" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.IdentityServerTestSuitInitializerTestCase"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-consent" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
+            <class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-discovery" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-governance" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>
+        </classes>
+    </test>
+    <!--<test name="is-tests-notification-mgt" preserve-order="true" parallel="false" group-by-instances="true">-->
+    <!--<classes>-->
+    <!--<class name="org.wso2.identity.integration.test.user.profile.mgt.NotificationOnUserOperationTestCase"/>-->
+    <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementNotificationTestCase"/>-->
+    <!--</classes>-->
+    <!--</test>-->
+
+    <test name="is-tests-usr-mgt" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.user.mgt.CARBON15502ReadWriteLDAPUserStoreManagerTestCase"/>-->
+            <!--<class name="org.wso2.identity.integration.test.user.mgt.remote.RemoteUserStoreManagerServiceTestCase" />-->
+        </classes>
+    </test>
+
+    <test name="is-analytics-tests" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.analytics.authentication.AnalyticsLoginTestCase"/>
+            <class name="org.wso2.identity.integration.test.analytics.oauth.OAuth2TokenIssuance"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-scim" preserve-order="true" parallel="false">
+        <classes>
+            <!--SCIM Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.scim.SCIMUserProviderTestCase" />-->
+            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />
+            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />
+            <class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase" />
+            <!--<class name="org.wso2.identity.integration.test.scim.SCIMGlobalProviderTestCase" />-->
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.AccountLockingWhileSCIMEnabledTestCase"/>-->
+        </classes>
+    </test>
+
+    <test name="is-tests-scim2" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-all" preserve-order="true" parallel="false">
+        <packages>
+            <!--Entitlement Test Cases-->
+            <!--<package name="org.wso2.identity.integration.test.entitlement"/>-->
+            <!--Application Management Test Cases-->
+            <!--<package name="org.wso2.identity.integration.test.application.mgt"/>-->
+        </packages>
+        <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
+            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.um.ws.api.RemoteAuthorizationManagerServiceTestCase" />-->
+            <class name="org.wso2.identity.integration.test.claim.metadata.mgt.ClaimMetadataManagementServiceTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.mgt.ClaimManagementServiceTestCase" />-->
+
+            <!--Identity Management Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.AccountCredentialMgtConfigServiceTestCase" />-->
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.UserIdentityManagementServiceTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.PasswordHistoryValidationTestCase"/>-->
+
+            <class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/>
+
+
+            <!--User Store Test Cases-->
+            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/>
+            <class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/>
+            <!--Provisioning Test Cases-->
+            <class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/>
+            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
+            <!--OAuth Test Cases-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantCacheDisabledTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeAfterCacheTimeOutTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>
+
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/>
+            <!--XACML based scope validation test-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/>
+
+            <!--
+                https://wso2.org/jira/browse/IDENTITY-6829 Need to fix this and comment out the test case ASAP.
+            -->
+            <!--<class name="org.wso2.identity.integration.test.oauth2.IDENTITY6777OAuth2TokenExpiryTestCase"/>-->
+
+            <!--OIDC Test Cases-->
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/>
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>
+
+            <!--OpenId Test Cases-->
+            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />
+            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />
+            <!--<class name="org.wso2.identity.integration.test.openid.OpenIDUserProfileTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>
+            <class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase" />
+            <!--PassiveSTS Test Cases-->
+            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/>
+            <class name="org.wso2.identity.integration.test.sts.TestPassiveSTSFederation"/>
+            <!--User Profile Management Test Cases-->
+            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
+            <!--SAML Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLIdentityFederationTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
+            <!-- <class name="org.wso2.identity.integration.test.saml.SPMetaDataTenantTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/>
+
+            <class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/>
+
+            <!--Workflow Management test case-->
+            <class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/>
+
+            <!--Identity Provider Management Test Cases-->
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" />
+            <!--Entitlement Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementPIPAttributeCacheTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
+            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>
+
+            <!-- Request path authenticator test cases-->
+            <class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" />
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
+            <class name="org.wso2.identity.integration.test.dashboard.IDENTITY5811TestCase" />
+            <class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" />
+            <!--class name="org.wso2.identity.integration.test.auth.IdentifierFirstLoginTestCase" /-->
+            <class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" />
+        </classes>
+    </test>
+
+    <test name="UserStore-config-encryption-tests" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!--TODO uncomment after kernel 4.4.23 and carbon-identity-framework 5.11.51 upgrade-->
+            <!--<class name="org.wso2.identity.integration.test.user.store.config.UserStorePasswordEncryption"/>-->
+        </classes>
+    </test>
+
+    <test name="is-tests-sequential" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/>
+            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/>
+            <class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLLocalAndOutboundAuthenticatorsTestCase"/>-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/-->
+            <class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-saml-sequential" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/>
+            <class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/>
+        </classes>
+    </test>
+    <test name="is-tests-oauth2-encryption" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/>
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/>
+        </classes>
+    </test>
+    <test name="xacml-entitlement-testcases" preserve-order="true" parallel="false">
+        <classes>
+            <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementJSONSupportMultiDecisionProfileTestCase"/>-->
+        </classes>
+    </test>
+</suite>

--- a/integration-tests/testng-server-mgt.xml
+++ b/integration-tests/testng-server-mgt.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="identity-suite">
+    <parameter name="useDefaultListeners" value="false"/>
+    <listeners>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestExecutionListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestManagerListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestSuiteListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestTransformerListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestReportListener"/>
+    </listeners>
+    <test name="verifyServer" preserve-order="true" parallel="false">
+        <classes>
+            <!--<class name="ServerStartupTestCase"/>-->
+        </classes>
+    </test>
+</suite>

--- a/integration-tests/testng.xml
+++ b/integration-tests/testng.xml
@@ -1,0 +1,236 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Identity-suite-initializer">
+    <parameter name="useDefaultListeners" value="false"/>
+    <listeners>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestExecutionListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestManagerListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestReportListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestSuiteListener"/>
+        <listener class-name="org.wso2.carbon.automation.engine.testlisteners.TestTransformerListener"/>
+        <listener class-name="org.wso2.identity.integration.test.listeners.IdentityTestListener"/>
+    </listeners>
+
+    <test name="is-tests-initialize" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.IdentityServerTestSuitInitializerTestCase"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-consent" parallel="false" group-by-instances="true">
+        <classes>
+            <!--class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/-->
+            <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
+            <!--class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/-->
+        </classes>
+    </test>
+
+    <test name="is-tests-discovery" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.OIDCDiscoveryTestCase"/>
+        </classes>
+    </test>
+
+    <test name="is-tests-governance" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.identity.governance.AdminForcedPasswordResetTestCase"/>
+        </classes>
+    </test>
+    <!--<test name="is-tests-notification-mgt" preserve-order="true" parallel="false" group-by-instances="true">-->
+    <!--<classes>-->
+    <!--<class name="org.wso2.identity.integration.test.user.profile.mgt.NotificationOnUserOperationTestCase"/>-->
+    <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementNotificationTestCase"/>-->
+    <!--</classes>-->
+    <!--</test>-->
+
+    <test name="is-tests-usr-mgt" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLdapBasedUserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadWriteLDAPUserStoreManagerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.ReadOnlyLDAPUserStoreManagerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.JDBCBasedUserMgtTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.JDBCUserStoreManagerTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.CARBON15051EmailLoginTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.mgt.UserMgtUISecurityTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.user.mgt.CARBON15502ReadWriteLDAPUserStoreManagerTestCase"/>-->
+            <!--<class name="org.wso2.identity.integration.test.user.mgt.remote.RemoteUserStoreManagerServiceTestCase" />-->
+        </classes>
+    </test>
+
+    <test name="is-analytics-tests" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!--class name="org.wso2.identity.integration.test.analytics.authentication.AnalyticsLoginTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.analytics.oauth.OAuth2TokenIssuance"/-->
+        </classes>
+    </test>
+
+    <test name="is-tests-scim" preserve-order="true" parallel="false">
+        <classes>
+            <!--SCIM Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.scim.SCIMUserProviderTestCase" />-->
+            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderUserTestCase" />
+            <class name="org.wso2.identity.integration.test.scim.SCIMServiceProviderGroupTestCase" />
+            <!--class name="org.wso2.identity.integration.test.scim.IDENTITY4776SCIMServiceWithOAuthTestCase" /-->
+            <!--<class name="org.wso2.identity.integration.test.scim.SCIMGlobalProviderTestCase" />-->
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.AccountLockingWhileSCIMEnabledTestCase"/>-->
+        </classes>
+    </test>
+
+    <test name="is-tests-scim2" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2BaseTestCase"/>
+            <class name="org.wso2.identity.integration.test.scim2.SCIM2UserTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.scim2.SCIM2GroupTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.scim2.SCIM2MeTestCase"/-->
+        </classes>
+    </test>
+
+    <test name="is-tests-all" preserve-order="true" parallel="false">
+        <packages>
+            <!--Entitlement Test Cases-->
+            <!--<package name="org.wso2.identity.integration.test.entitlement"/>-->
+            <!--Application Management Test Cases-->
+            <!--<package name="org.wso2.identity.integration.test.application.mgt"/>-->
+        </packages>
+        <classes>
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceJWTGrantTestCase"/>
+            <class name="org.wso2.identity.integration.test.user.account.connector.UserAccountConnectorTestCase"/>
+            <class name="org.wso2.identity.integration.test.AuthenticationAdminTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.um.ws.api.RemoteAuthorizationManagerServiceTestCase" />-->
+            <class name="org.wso2.identity.integration.test.claim.metadata.mgt.ClaimMetadataManagementServiceTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.mgt.ClaimManagementServiceTestCase" />-->
+
+            <!--Identity Management Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.AccountCredentialMgtConfigServiceTestCase" />-->
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.UserIdentityManagementServiceTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.identity.mgt.UserInformationRecoveryServiceTenantEmailUserTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.AccountLockEnabledTestCase"/>
+            <class name="org.wso2.identity.integration.test.identity.mgt.IdentityGovernanceTestCase"/>
+            <!--<class name="org.wso2.identity.integration.test.identity.mgt.PasswordHistoryValidationTestCase"/>-->
+
+            <!--class name="org.wso2.identity.integration.test.challenge.questions.mgt.ChallengeQuestionManagementAdminServiceTestCase"/-->
+
+
+            <!--User Store Test Cases-->
+            <!--class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigAdminTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.user.store.config.UserStoreConfigTestForIDENTITY5573"/-->
+            <!--class name="org.wso2.identity.integration.test.user.store.config.UserStoreDeployerTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/-->
+            <!--Provisioning Test Cases-->
+            <!--class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/-->
+            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
+            <!--OAuth Test Cases-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuth2RequestObjectSignatureValidationTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2IDTokenEncryptionTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceClientCredentialTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceImplicitGrantTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRegexCallbackUrlTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceResourceOwnerTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantTestCase"/-->
+            <!--<class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantCacheDisabledTestCase"/>-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeAfterCacheTimeOutTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2TokenRevokeWithInvalidClientCredentialsTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceErrorResponseTest"/-->
+            <class name="org.wso2.identity.integration.test.oauth2.OAuthAdminServiceTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceIntrospectionTestCase"/-->
+            <class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceSAML2BearerGrantTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceRefreshTokenGrantTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/-->
+
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ScopesTestCase"/-->
+            <!--XACML based scope validation test-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2XACMLScopeValidatorTestCase"/-->
+
+            <!--
+                https://wso2.org/jira/browse/IDENTITY-6829 Need to fix this and comment out the test case ASAP.
+            -->
+            <!--<class name="org.wso2.identity.integration.test.oauth2.IDENTITY6777OAuth2TokenExpiryTestCase"/>-->
+
+            <!--OIDC Test Cases-->
+            <!--class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSOTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oidc.OIDCAuthCodeGrantSSODifferentSubjectIDTestCase"/-->
+            <class name="org.wso2.identity.integration.test.oidc.OIDCAuthzCodeIdTokenValidationTestCase"/>
+
+            <!--OpenId Test Cases-->
+            <class name="org.wso2.identity.integration.test.openid.OpenIDAuthenticationTestCase" />
+            <class name="org.wso2.identity.integration.test.openid.OpenIDProviderServerConfigTestCase" />
+            <!--<class name="org.wso2.identity.integration.test.openid.OpenIDUserProfileTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.openid.OpenIDRPManagementTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.openid.OpenIDSSOTestCase" /-->
+            <!--PassiveSTS Test Cases-->
+            <!--class name="org.wso2.identity.integration.test.sts.TestPassiveSTS"/-->
+            <!--class name="org.wso2.identity.integration.test.sts.TestPassiveSTSFederation"/-->
+            <!--User Profile Management Test Cases-->
+            <class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileMgtTestCase"/>
+            <!--SAML Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLIdentityFederationTestCase"/>-->
+            <!--class name="org.wso2.identity.integration.test.saml.SAMLInvalidIssuerTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.saml.RegistryMountTestCase"/-->
+            <class name="org.wso2.identity.integration.test.saml.SPMetadataTestCase"/>
+            <!-- <class name="org.wso2.identity.integration.test.saml.SPMetaDataTenantTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.saml.IDPMetadataTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.saml.SAMLFederationDynamicQueryParametersTestCase"/-->
+
+            <!--class name="org.wso2.identity.integration.test.provisioning.JustInTimeProvisioningTestCase"/-->
+
+            <!--Workflow Management test case-->
+            <!--class name="org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase"/-->
+
+            <!--Identity Provider Management Test Cases-->
+            <!--class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderManagementTestCase" /-->
+            <!--Entitlement Test Cases-->
+            <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementPIPAttributeCacheTestCase"/>-->
+            <class name="org.wso2.identity.integration.test.entitlement.EntitlementSecurityTestCase"/>
+            <class name="org.wso2.identity.integration.test.entitlement.EntitlementRestServiceTestCase"/>
+
+            <!-- Request path authenticator test cases-->
+            <!--class name="org.wso2.identity.integration.test.requestPathAuthenticator.SAMLWithRequestPathAuthenticationTest" /-->
+            <class name="org.wso2.identity.integration.test.idp.mgt.IdentityProviderMgtServiceTestCase" />
+            <class name="org.wso2.identity.integration.test.dashboard.IDENTITY5811TestCase" />
+            <!--class name="org.wso2.identity.integration.test.auth.ConditionalAuthenticationTestCase" /-->
+            <class name="org.wso2.identity.integration.test.auth.IdentifierFirstLoginTestCase" />
+            <!--class name="org.wso2.identity.integration.test.auth.RiskBasedLoginTestCase" /-->
+        </classes>
+    </test>
+
+    <test name="UserStore-config-encryption-tests" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!--TODO uncomment after kernel 4.4.23 and carbon-identity-framework 5.11.51 upgrade-->
+            <!--<class name="org.wso2.identity.integration.test.user.store.config.UserStorePasswordEncryption"/>-->
+        </classes>
+    </test>
+
+    <test name="is-tests-sequential" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLQueryProfileTestCase"/>-->
+            <!--class name="org.wso2.identity.integration.test.saml.SAMLSSOTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.application.authz.ApplicationAuthzTenantTestCase"/-->
+            <!--<class name="org.wso2.identity.integration.test.saml.SAMLLocalAndOutboundAuthenticatorsTestCase"/>-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.dcrm.api.OAuthDCRMTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.saml.SAMLErrorResponseTestCase"/-->
+        </classes>
+    </test>
+    <test name="is-tests-saml-sequential" preserve-order="true" parallel="false">
+        <classes>
+            <!--class name="org.wso2.identity.integration.test.saml.ChangeACSUrlTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.saml.SAMLFederationWithFileBasedSPAndIDPTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.user.profile.mgt.UserProfileAdminTestCase"/-->
+        </classes>
+    </test>
+    <test name="is-tests-oauth2-encryption" preserve-order="true" parallel="false">
+        <classes>
+            <!--class name="org.wso2.identity.integration.test.oauth2.Oauth2PersistenceProcessorInsertTokenTestCase"/-->
+            <!--class name="org.wso2.identity.integration.test.oauth2.Oauth2HashAlgorithmTestCase"/-->
+        </classes>
+    </test>
+    <test name="xacml-entitlement-testcases" preserve-order="true" parallel="false">
+        <classes>
+            <!--<class name="org.wso2.identity.integration.test.entitlement.EntitlementJSONSupportMultiDecisionProfileTestCase"/>-->
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose
This PR contains the necessary changes needs to execute integration tests for IS against a given custom testng.xml.
A custom testng file is also attached which is only contain handful of failing test-cases. (Rest of the failing tests are commented-out).
Enabled failing test-cases;

```
1.EntitlementRestServiceTestCase
2.DBSeperationTestCase
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes