### PR TITLE
Change custom-testng xml file

### DIFF
--- a/integration-tests/testng.xml
+++ b/integration-tests/testng.xml
@@ -19,7 +19,7 @@
 
     <test name="is-tests-consent" parallel="false" group-by-instances="true">
         <classes>
-            <!--class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/-->
+            <class name="org.wso2.identity.integration.test.consent.ConsentMgtTestCase"/>
             <class name="org.wso2.identity.integration.test.user.export.UserInfoExportTestCase" />
             <!--class name="org.wso2.identity.integration.test.consent.SelfSignUpConsentTest"/-->
         </classes>
@@ -119,7 +119,7 @@
             <!--class name="org.wso2.identity.integration.test.user.store.JDBCUserStoreAddingTestCase"/-->
             <!--Provisioning Test Cases-->
             <!--class name="org.wso2.identity.integration.test.provisioning.ProvisioningTestCase"/-->
-            <class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/>
+            <!--class name="org.wso2.identity.integration.test.provisioning.DBSeperationTestCase"/-->
             <!--OAuth Test Cases-->
             <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdTestCase"/-->
             <!--class name="org.wso2.identity.integration.test.oauth2.OAuth2ServiceAuthCodeGrantOpenIdRequestObjectTestCase"/-->


### PR DESCRIPTION
## Purpose
To change enabled failing test-case since the previous enable case is failing on all the infra-combinations.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes