### PR TITLE
Get JVM metrics from Windows

### DIFF
--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -139,18 +139,7 @@ def modify_pom_files():
         artifact_tree.write(file_path)
 
 
-def attach_jolokia_agent(spath):
-    logger.info('attaching jolokia agent as a java agent')
-    sp = str(spath)
-    with open(sp, "r") as in_file:
-        buf = in_file.readlines()
-
-    with open(sp, "w") as out_file:
-        for line in buf:
-            if line == "    $JAVACMD \\\n":
-                line = line + "    -javaagent:/opt/wso2/jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http \\\n"
-                logger.info(line)
-            out_file.write(line)
+git
 
 
 def modify_datasources():

--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -139,7 +139,34 @@ def modify_pom_files():
         artifact_tree.write(file_path)
 
 
-git
+def attach_jolokia_agent(spath):
+    logger.info('attaching jolokia agent as a java agent')
+    sp = str(spath)
+
+    if sys.platform.startswith('win'):
+        sp = sp + ".bat"
+        jolokia_agent = "-javaagent:C:\\testgrid\\jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http "
+        with open(sp, "r") as in_file:
+            buf = in_file.readlines()
+        with open(sp, "w") as out_file:
+            for line in buf:
+                if line.startswith("set CMD_LINE_ARGS"):
+                    newline = str(line).replace("CMD_LINE_ARGS=", 'CMD_LINE_ARGS='+jolokia_agent)
+                    line = newline
+                    logger.info(newline)
+                out_file.write(line)
+    else:
+        sp = sp + ".sh"
+        jolokia_agent = \
+            "    -javaagent:/opt/wso2/jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http \\\n"
+        with open(sp, "r") as in_file:
+            buf = in_file.readlines()
+        with open(sp, "w") as out_file:
+            for line in buf:
+                if line == "    $JAVACMD \\\n":
+                    line = line + jolokia_agent
+                    logger.info(line)
+                out_file.write(line)
 
 
 def modify_datasources():

--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -15,7 +15,7 @@
 NS = {'d': 'http://maven.apache.org/POM/4.0.0'}
 ZIP_FILE_EXTENSION = ".zip"
 CARBON_NAME = "carbon.zip"
-WSO2SERVER = "bin/wso2server.sh"
+WSO2SERVER = "bin/wso2server"
 VALUE_TAG = "{http://maven.apache.org/POM/4.0.0}value"
 SURFACE_PLUGIN_ARTIFACT_ID = "maven-surefire-plugin"
 DATASOURCE_PATHS = {"product-apim": ["repository/conf/datasources/master-datasources.xml",


### PR DESCRIPTION
## Purpose
Currently only test plans with CentOS as the OS is collecting JVM metrics. As a result the product performance dashboard for windows test plans is displaying a no data for JVM graphs. This PR is to fix that issue

## Goals
Collect and visualize JVM metrics for windows

## Approach
Attach Jolokia java agent which will pull JVM metrics from the JVM of the tested product. This is done by modifying wso2server.bat file in product .

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes