### PR TITLE
Fix Mysql Commit Issue for Consent related Integration Test Failures

### DIFF
--- a/integration-tests/run-intg-test.py
+++ b/integration-tests/run-intg-test.py
@@ -298,6 +298,7 @@ def run_mysql_script_file(db_name, script_path):
         if sql_part.strip() == '':
             continue
         connector.execute(sql_part)
+    conn.commit();
     conn.close()
 
 


### PR DESCRIPTION
## Purpose
> This fix will allow mysql commits done through python script such as 'insert' operations to be committed to the relevant database.

## Goals
> To Fix -> 'ConsentMgtTestCase#testAddReceipt', 'SelfSignUpConsentTest#getPurposes' and 'SelfSignUpConsentTest#selfSignUpWithConsents' in Identity Integration Tests.

